### PR TITLE
Enable tmux passthrough to fix Claude Code TUI flicker

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -24,6 +24,11 @@ set -g default-terminal "tmux-256color"
 set -as terminal-features 'tmux-256color:RGB'
 set -as terminal-overrides ',xterm-ghostty:RGB'
 
+# Enable passthrough for DEC 2026 synchronized output (fixes Claude Code TUI flicker)
+set -g allow-passthrough on
+set -g set-clipboard on
+set -s extended-keys on
+
 # Set the repeat time
 set -g repeat-time 250
 


### PR DESCRIPTION
## Summary
- Enable `allow-passthrough` for DEC 2026 synchronized output (fixes Claude Code TUI flicker in tmux)
- Enable `set-clipboard` and `extended-keys` for proper terminal integration

## Test plan
- [ ] Verify Claude Code runs without flicker inside tmux
- [ ] Confirm clipboard operations work through tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)